### PR TITLE
Add function coglu_shader_load_program

### DIFF
--- a/include/coglu.h
+++ b/include/coglu.h
@@ -50,7 +50,7 @@ unsigned int coglu_shader_compile(const char *shader_path, int shader_type) {
     return shader;
 }
 
-int coglu_shader_load_program(const char *vertex_shader_path,
+unsigned int coglu_shader_load_program(const char *vertex_shader_path,
                               const char *fragment_shader_path) {
     // Compile shaders
     unsigned int vertex_shader = coglu_shader_compile(vertex_shader_path,

--- a/include/coglu.h
+++ b/include/coglu.h
@@ -51,7 +51,7 @@ unsigned int coglu_shader_compile(const char *shader_path, int shader_type) {
 }
 
 unsigned int coglu_shader_load_program(const char *vertex_shader_path,
-                              const char *fragment_shader_path) {
+                                       const char *fragment_shader_path) {
     // Compile shaders
     unsigned int vertex_shader = coglu_shader_compile(vertex_shader_path,
                                                       GL_VERTEX_SHADER);


### PR DESCRIPTION
This function style applies to the coding style in my current application, where opengl ids are passed back as a result. 

I changed `coglu_shader_add_program` to keep the same interface while using `coglu_shader_load_program`.

Both functions were tested inside my application.